### PR TITLE
simplified dictionary creation

### DIFF
--- a/src/flask/sansio/blueprints.py
+++ b/src/flask/sansio/blueprints.py
@@ -387,7 +387,7 @@ class Blueprint(Scaffold):
             value = defaultdict(
                 dict,
                 {
-                    code: {exc_class: func for exc_class, func in code_values.items()}
+                    code: dict(code_values.items())
                     for code, code_values in value.items()
                 },
             )


### PR DESCRIPTION
this line :

    code: {exc_class: func for exc_class, func in code_values.items()}

    is creating a new dictionary from code_values.items() using dictionary comprehension.sincie it is just recreating the dictionary without modifying the keys or values, I simply changed it to

    code: dict(code_values.items())